### PR TITLE
Add DynamoDB session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Orion Backend
+
+This project provides the backend services for the Orion chat assistant.
+
+## DynamoDB Tables
+
+Two DynamoDB tables are used by default:
+
+- `UserGoogleTokens` – stores encrypted Google OAuth tokens.
+- `ChatSessions` – stores chat session history.
+
+`ChatSessions` can be created with the helper `create_chat_sessions_table` in
+`app/dynamodb.py`.
+
+## Session Management
+
+`DynamoSessionManager` (defined in `app/session_manager.py`) uses the
+`ChatSessions` table to persist conversation history. It is now the default
+session manager returned by `get_session_manager` in `app/chat_router.py`.

--- a/app/chat_router.py
+++ b/app/chat_router.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from orchestration_service import handle_chat_request
 # --- Import Abstract Interfaces for Dependency Injection ---
-from session_manager import AbstractSessionManager, MongoSessionManager
+from session_manager import AbstractSessionManager, DynamoSessionManager
 from orchestration_service import AbstractGeminiClient
 from orchestration_service import AbstractToolExecutor
 from calendar_client import AbstractCalendarClient, GoogleCalendarAPIClient
@@ -35,8 +35,8 @@ logger = logging.getLogger(__name__)
 def get_session_manager() -> AbstractSessionManager:
     # Replace with logic to get/create a session manager instance
     # Might involve getting DB connection from another dependency
-    logger.warning("Using dummy MongoSessionManager instance")
-    return MongoSessionManager()  # Requires DB connection setup elsewhere
+    logger.warning("Using DynamoSessionManager instance")
+    return DynamoSessionManager()
 
 
 def get_gemini_client() -> AbstractGeminiClient:

--- a/app/dynamodb.py
+++ b/app/dynamodb.py
@@ -54,9 +54,34 @@ def create_user_tokens_table():
     except Exception as e:
         print(f"Error creating table {table_name}: {e}")
 
+
+def create_chat_sessions_table():
+    dynamodb = get_dynamodb_resource()
+    table_name = settings.DYNAMODB_CHAT_SESSIONS_TABLE_NAME
+
+    try:
+        table = dynamodb.create_table(
+            TableName=table_name,
+            KeySchema=[
+                {"AttributeName": "session_id", "KeyType": "HASH"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "session_id", "AttributeType": "S"},
+            ],
+            ProvisionedThroughput={
+                "ReadCapacityUnits": 5,
+                "WriteCapacityUnits": 5,
+            },
+        )
+        table.wait_until_exists()
+        print(f"Table {table_name} created successfully.")
+    except Exception as e:
+        print(f"Error creating table {table_name}: {e}")
+
 #create_user_tokens_table()
 
 user_tokens_table = get_dynamodb_resource().Table(settings.DYNAMODB_USER_TOKENS_TABLE_NAME)
+chat_sessions_table = get_dynamodb_resource().Table(settings.DYNAMODB_CHAT_SESSIONS_TABLE_NAME)
 
 
 def save_user_tokens(

--- a/app/settings_v1.py
+++ b/app/settings_v1.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     # GOOGLE_CLIENT_SECRET is no longer used in token exchange as per user's findings
     AWS_REGION: str = "eu-north-1"
     DYNAMODB_USER_TOKENS_TABLE_NAME: str = "UserGoogleTokens"
+    DYNAMODB_CHAT_SESSIONS_TABLE_NAME: str = "ChatSessions"
     AWS_DYNAMODB_ENDPOINT_URL: Optional[str] = None  # Optional for local development/testing
 
     # ENCRYPTION_KEY must be a 32-byte (256-bit) key.


### PR DESCRIPTION
## Summary
- support chat session storage via DynamoDB
- implement `DynamoSessionManager`
- update settings for new table name
- switch chat router to use `DynamoSessionManager`
- document DynamoDB tables and session manager in README

## Testing
- `python3 -m py_compile app/settings_v1.py app/dynamodb.py app/session_manager.py app/chat_router.py`
