### PR TITLE
Add unit tests for API routers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /app/__pycache__
+__pycache__/

--- a/tests/test_auth_router.py
+++ b/tests/test_auth_router.py
@@ -1,0 +1,85 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), "app"))
+import time
+os.environ.setdefault("GOOGLE_CLIENT_ID_IOS", "ios")
+os.environ.setdefault("GOOGLE_CLIENT_ID_ANDROID", "android")
+os.environ.setdefault("ENCRYPTION_KEY_HEX", "0"*64)
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import httpx
+
+import app.auth_router as auth_router
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+class DummyClient:
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def post(self, url, data=None, headers=None):
+        return DummyResponse({"access_token": "a", "refresh_token": "r", "expires_in": 3600, "scope": "s"})
+
+@pytest.fixture
+def test_app():
+    app = FastAPI()
+    app.include_router(auth_router.router)
+    return app
+
+
+def test_connect_google_calendar(monkeypatch, test_app):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient())
+    monkeypatch.setattr(auth_router, "save_user_tokens", lambda **kwargs: "success")
+    monkeypatch.setattr(auth_router, "get_decrypted_user_tokens", lambda uid: {"access_token": "a"})
+    monkeypatch.setattr(auth_router, "encrypt_token", lambda token, key: (b"iv", b"ct", b"tag"))
+    monkeypatch.setattr(auth_router, "decrypt_token", lambda iv, ct, tag, key: ct)
+    monkeypatch.setattr(auth_router.uuid, "uuid4", lambda: "fixed-id")
+
+    client = TestClient(test_app)
+    payload = {
+        "authorization_code": "code",
+        "platform": "ios",
+        "code_verifier": "ver",
+        "redirect_uri": "https://example.com/cb"
+    }
+    resp = client.post("/auth/google/connect", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["user_id"] == "fixed-id"
+
+
+def test_disconnect_google_calendar(monkeypatch, test_app):
+    monkeypatch.setattr(auth_router, "delete_user_tokens", lambda uid: True)
+    client = TestClient(test_app)
+    resp = client.post("/auth/auth/google/disconnect")
+    assert resp.status_code == 200
+
+
+def test_list_google_calendars(monkeypatch, test_app):
+    monkeypatch.setattr(auth_router, "get_decrypted_user_tokens", lambda uid: {"access_token": "abc", "access_token_expires_at": time.time()+1000})
+    client = TestClient(test_app)
+    resp = client.get("/auth/calendar/meta/list-calendars")
+    assert resp.status_code == 200
+    assert resp.json()["user_id"] == "dummy_user_id_123"
+
+
+
+def test_refresh_token(monkeypatch, test_app):
+    async def dummy_refresh(uid):
+        return "newtoken"
+    monkeypatch.setattr(auth_router, "refresh_google_access_token", dummy_refresh)
+    client = TestClient(test_app)
+    resp = client.post("/auth/auth/google/refresh-test")
+    assert resp.status_code == 200
+    assert resp.json()["new_access_token_snippet"].startswith("newtoken"[:10])
+

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1,0 +1,75 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), "app"))
+os.environ.setdefault("GOOGLE_CLIENT_ID_IOS", "ios")
+os.environ.setdefault("GOOGLE_CLIENT_ID_ANDROID", "android")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+os.environ.setdefault("ENCRYPTION_KEY_HEX", "0"*64)
+import json
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import app.chat_router as chat_router
+from app.models import ChatRequest, ChatResponse, ResponseStatus
+
+class DummySessionManager:
+    async def get_history(self, session_id):
+        return []
+    async def append_turn(self, session_id, turn):
+        pass
+    async def create_session(self, user_id):
+        return "session_created"
+
+class DummyCalendarClient:
+    pass
+
+@pytest.fixture
+def test_app():
+    app = FastAPI()
+    app.include_router(chat_router.router)
+    return app
+
+
+def test_root_endpoint(test_app):
+    client = TestClient(test_app)
+    resp = client.get("/chat/")
+    assert resp.status_code == 200
+    assert resp.json()["message"].startswith("Orion")
+
+
+def test_create_user_success(test_app):
+    client = TestClient(test_app)
+    payload = {"user_id": "new_user", "email": "a@b.c", "password": "pw"}
+    resp = client.post("/chat/users/create", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["user"]["user_id"] == "new_user"
+
+
+def test_create_user_exists(test_app):
+    client = TestClient(test_app)
+    payload = {"user_id": "existing_user", "email": "a@b.c", "password": "pw"}
+    resp = client.post("/chat/users/create", json=payload)
+    assert resp.status_code == 500
+
+
+def test_process_chat_prompt(monkeypatch, test_app):
+    async def dummy_handle_chat_request(**kwargs):
+        return ChatResponse(session_id="s1", status=ResponseStatus.COMPLETED, response_text="done")
+
+    monkeypatch.setattr(chat_router, "handle_chat_request", dummy_handle_chat_request)
+    monkeypatch.setattr(chat_router, "verify_token", lambda credentials: "user_from_token")
+    monkeypatch.setattr(chat_router, "get_session_manager", lambda: DummySessionManager())
+    monkeypatch.setattr(chat_router, "get_gemini_client", lambda: object())
+    monkeypatch.setattr(chat_router, "get_tool_executor", lambda: object())
+    monkeypatch.setattr(chat_router, "get_calendar_client", lambda email: DummyCalendarClient())
+
+    client = TestClient(test_app)
+    payload = {"user_id": "user_from_token", "session_id": None, "prompt_text": "hi"}
+    resp = client.post("/chat/prompt", json=payload, headers={"Authorization": "Bearer abc"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == ResponseStatus.COMPLETED
+

--- a/tests/test_conversation_router.py
+++ b/tests/test_conversation_router.py
@@ -1,0 +1,35 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), "app"))
+import pytest
+os.environ.setdefault("GOOGLE_CLIENT_ID_IOS", "ios")
+os.environ.setdefault("GOOGLE_CLIENT_ID_ANDROID", "android")
+os.environ.setdefault("ENCRYPTION_KEY_HEX", "0"*64)
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import app.conversation_router as conversation_router
+
+@pytest.fixture
+def test_app():
+    app = FastAPI()
+    app.include_router(conversation_router.router)
+    return app
+
+
+def test_list_user_conversations(monkeypatch, test_app):
+    sample = [
+        {"session_id": "s1", "user_id": "u1", "history": []},
+        {"session_id": "s2", "user_id": "u1", "history": []},
+    ]
+    monkeypatch.setattr(conversation_router, "get_user_conversations", lambda uid: sample)
+    client = TestClient(test_app)
+    resp = client.get("/conversations/u1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    assert data[0]["session_id"] == "s1"
+

--- a/tests/test_event_app.py
+++ b/tests/test_event_app.py
@@ -1,0 +1,34 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), "app"))
+import pytest
+os.environ.setdefault("GOOGLE_CLIENT_ID_IOS", "ios")
+os.environ.setdefault("GOOGLE_CLIENT_ID_ANDROID", "android")
+os.environ.setdefault("ENCRYPTION_KEY_HEX", "0"*64)
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+from fastapi.testclient import TestClient
+
+from app.quick_insert_event_app import app as event_app
+import app.quick_insert_event_app as event_module
+
+
+def test_post_event(monkeypatch):
+    def dummy_schedule(startDate, startTime, endDate, endTime, topic, description, tz):
+        return {"id": "1", "_id": "1", "summary": topic}
+    monkeypatch.setattr(event_module, "schedule_event", dummy_schedule)
+    client = TestClient(event_app)
+    payload = {
+        "startTime": "10:00:00",
+        "endTime": "11:00:00",
+        "startDate": "2023-01-01",
+        "endDate": "2023-01-01",
+        "topic": "test",
+        "description": "d",
+        "attendees": []
+    }
+    resp = client.post("/events/", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Event creation request received"
+


### PR DESCRIPTION
## Summary
- add fastapi unit tests covering chat, auth, conversation and event routes
- configure basic environment variables in tests to satisfy settings
- update `.gitignore` for pycache

## Testing
- `pytest -q`