### PR TITLE
Add router tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from pathlib import Path
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure the repository root (which contains the ``app`` package) is on
+# ``sys.path``. Some modules import ``settings_v1`` from the root, so the
+# root must be discoverable during tests.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "app"
+for path in (str(REPO_ROOT), str(APP_DIR)):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+# Ensure required environment variables for settings
+os.environ.setdefault("GOOGLE_CLIENT_ID_IOS", "dummy")
+os.environ.setdefault("GOOGLE_CLIENT_ID_ANDROID", "dummy")
+os.environ.setdefault("ENCRYPTION_KEY_HEX", "0"*64)
+
+# Prevent boto3 from attempting network calls when modules import DynamoDB
+import boto3
+
+class _DummyTable:
+    def __getattr__(self, item):
+        def _dummy(*args, **kwargs):
+            return None
+        return _dummy
+
+
+class _DummyResource:
+    def Table(self, name):
+        return _DummyTable()
+
+boto3.resource = lambda *args, **kwargs: _DummyResource()
+
+from app.core import security
+from app import auth_router, chat_router, conversation_router, events_router, user_preferences_router
+
+
+def create_test_client(verify_user_id: str = "test_user", current_user: dict | None = None) -> TestClient:
+    app = FastAPI()
+    app.include_router(auth_router.router)
+    app.include_router(chat_router.router)
+    app.include_router(conversation_router.router)
+    app.include_router(events_router.router)
+    app.include_router(user_preferences_router.router)
+
+    async def override_verify_token(credentials=None):
+        return verify_user_id
+
+    async def override_get_current_user(credentials=None):
+        return current_user or {"user_id": verify_user_id, "email": "test@example.com"}
+
+    # Override authentication dependencies used across routers
+    app.dependency_overrides[security.verify_token] = override_verify_token
+    app.dependency_overrides[security.get_current_user] = override_get_current_user
+    app.dependency_overrides[auth_router.get_current_user] = override_get_current_user
+    app.dependency_overrides[events_router.verify_token] = override_verify_token
+    app.dependency_overrides[conversation_router.verify_token] = override_verify_token
+    app.dependency_overrides[chat_router.verify_token] = override_verify_token
+    app.dependency_overrides[user_preferences_router.verify_token] = override_verify_token
+
+    client = TestClient(app)
+    # Provide a default authorization header so HTTPBearer does not reject requests
+    client.headers.update({"Authorization": "Bearer testtoken"})
+    return client

--- a/tests/test_auth_router.py
+++ b/tests/test_auth_router.py
@@ -1,0 +1,97 @@
+import uuid
+from unittest.mock import AsyncMock
+from tests.conftest import create_test_client
+
+
+def test_connect_google_calendar_success(monkeypatch):
+    client = create_test_client()
+
+    tokens = {
+        "access_token": "g_access",
+        "refresh_token": "g_refresh",
+        "expires_in": 3600,
+        "scope": "scope",
+        "id_token": "id_token",
+    }
+
+    class DummyResponse:
+        def json(self):
+            return tokens
+
+        def raise_for_status(self):
+            pass
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, data=None, headers=None):
+            return DummyResponse()
+
+    monkeypatch.setattr("app.auth_router.httpx.AsyncClient", lambda: DummyClient())
+    monkeypatch.setattr("app.auth_router.save_user_tokens", lambda **kwargs: "success")
+    monkeypatch.setattr("app.auth_router.get_decrypted_user_tokens", lambda uid: tokens)
+    monkeypatch.setattr("app.auth_router.encrypt_token", lambda token, key: (b"iv", b"ct", b"tag"))
+    monkeypatch.setattr("app.auth_router.decrypt_token", lambda *a, **kw: "token")
+    monkeypatch.setattr("app.auth_router.create_access_token", lambda data: "jwt_token")
+    monkeypatch.setattr("app.auth_router.uuid.uuid4", lambda: uuid.UUID("00000000-0000-0000-0000-000000000001"))
+
+    payload = {
+        "authorization_code": "code",
+        "platform": "ios",
+        "code_verifier": "ver",
+        "redirect_uri": "http://localhost",
+    }
+    response = client.post("/auth/google/connect", json={"payload": payload})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["access_token"] == "jwt_token"
+    assert data["user_id"] == "00000000-0000-0000-0000-000000000001"
+
+
+def test_connect_google_calendar_invalid_platform(monkeypatch):
+    client = create_test_client()
+    # patch network functions though they won't be used
+    monkeypatch.setattr("app.auth_router.httpx.AsyncClient", AsyncMock)
+    payload = {
+        "authorization_code": "code",
+        "platform": "windows",
+        "code_verifier": "ver",
+        "redirect_uri": "http://localhost",
+    }
+    response = client.post("/auth/google/connect", json={"payload": payload})
+    assert response.status_code == 400
+
+
+def test_disconnect_google_calendar(monkeypatch):
+    client = create_test_client()
+    monkeypatch.setattr("app.auth_router.delete_user_tokens", lambda uid: True)
+    response = client.post("/auth/auth/google/disconnect")
+    assert response.status_code == 200
+    assert "Successfully" in response.json()["message"]
+
+
+def test_list_google_calendars(monkeypatch):
+    client = create_test_client()
+    monkeypatch.setattr("app.auth_router.get_decrypted_user_tokens", lambda uid: {"access_token": "tok", "access_token_expires_at": 9999999999})
+    monkeypatch.setattr("app.auth_router.refresh_google_access_token", AsyncMock(return_value="newtok"))
+    response = client.get("/auth/calendar/meta/list-calendars")
+    assert response.status_code == 200
+
+
+def test_refresh_token(monkeypatch):
+    client = create_test_client()
+    monkeypatch.setattr("app.auth_router.refresh_google_access_token", AsyncMock(return_value="newtok"))
+    response = client.post("/auth/auth/google/refresh-test")
+    assert response.status_code == 200
+    assert "new_access_token_snippet" in response.json()
+
+
+def test_get_current_user_info():
+    client = create_test_client()
+    response = client.get("/auth/me")
+    assert response.status_code == 200
+    assert response.json()["user_id"] == "test_user"

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock
+from tests.conftest import create_test_client
+from app.models import ChatResponse, ResponseStatus
+
+
+def test_chat_prompt_success(monkeypatch):
+    client = create_test_client()
+
+    async def mock_handle_chat_request(**kwargs):
+        return ChatResponse(session_id="s1", status=ResponseStatus.COMPLETED, response_text="hi")
+
+    monkeypatch.setattr("app.chat_router.handle_chat_request", mock_handle_chat_request)
+    monkeypatch.setattr("app.chat_router.get_session_manager", lambda: object())
+    monkeypatch.setattr("app.chat_router.get_gemini_client", lambda: object())
+    monkeypatch.setattr("app.chat_router.get_tool_executor", lambda: object())
+    monkeypatch.setattr("app.chat_router.get_calendar_client", lambda email: object())
+
+    payload = {"user_id": "test_user", "session_id": "s1", "prompt_text": "hello"}
+    response = client.post("/chat/prompt", json=payload)
+    assert response.status_code == 200
+    assert response.json()["session_id"] == "s1"
+
+
+def test_chat_prompt_mismatch_user(monkeypatch):
+    client = create_test_client(verify_user_id="other_user")
+    monkeypatch.setattr("app.chat_router.handle_chat_request", AsyncMock())
+    payload = {"user_id": "test_user", "session_id": "s1", "prompt_text": "hello"}
+    response = client.post("/chat/prompt", json=payload)
+    assert response.status_code == 403
+
+
+def test_chat_root():
+    client = create_test_client()
+    response = client.get("/chat/")
+    assert response.status_code == 200
+    assert "Orion" in response.json()["message"]

--- a/tests/test_conversation_router.py
+++ b/tests/test_conversation_router.py
@@ -1,0 +1,23 @@
+from tests.conftest import create_test_client
+
+
+def test_list_conversations_success(monkeypatch):
+    client = create_test_client()
+
+    sample_items = [
+        {"session_id": "s1", "user_id": "test_user", "history": []},
+        {"session_id": "s2", "user_id": "test_user", "history": []},
+    ]
+    monkeypatch.setattr("app.conversation_router.get_user_conversations", lambda uid: sample_items)
+
+    resp = client.get("/conversations/test_user")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+    assert len(resp.json()) == 2
+
+
+def test_list_conversations_mismatch(monkeypatch):
+    client = create_test_client(verify_user_id="other")
+    monkeypatch.setattr("app.conversation_router.get_user_conversations", lambda uid: [])
+    resp = client.get("/conversations/test_user")
+    assert resp.status_code == 403

--- a/tests/test_events_router.py
+++ b/tests/test_events_router.py
@@ -1,0 +1,38 @@
+import datetime
+from tests.conftest import create_test_client
+from app.models import TimeSlot
+
+
+def test_busy_slots_success(monkeypatch):
+    client = create_test_client()
+
+    class DummyCalendar:
+        def get_busy_slots(self, calendar_id, start_time, end_time):
+            return [TimeSlot(start_time=start_time, end_time=end_time)]
+
+    async def mock_get_client(user_id):
+        return DummyCalendar()
+
+    monkeypatch.setattr("app.events_router.get_calendar_client_for_user", mock_get_client)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    resp = client.get(f"/events/test_user/busy-slots?days=1&timezone=UTC")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["user_id"] == "test_user"
+    assert data["total_busy_slots"] == 1
+
+
+def test_busy_slots_timezone_error(monkeypatch):
+    client = create_test_client()
+    async def mock_get_client(user_id):
+        return None
+    monkeypatch.setattr("app.events_router.get_calendar_client_for_user", mock_get_client)
+    resp = client.get("/events/test_user/busy-slots?timezone=Bad/Zone")
+    assert resp.status_code == 400
+
+
+def test_busy_slots_user_mismatch(monkeypatch):
+    client = create_test_client(verify_user_id="other")
+    resp = client.get("/events/test_user/busy-slots")
+    assert resp.status_code == 403

--- a/tests/test_user_preferences_router.py
+++ b/tests/test_user_preferences_router.py
@@ -1,0 +1,61 @@
+from tests.conftest import create_test_client
+
+SAVED_PREFS = {
+    "user_id": "test_user",
+    "time_zone": "UTC",
+    "working_hours": {"0": {"start": "09:00", "end": "17:00"}},
+    "preferred_meeting_times": [],
+    "days_off": [],
+    "preferred_break_duration_minutes": 15,
+    "work_block_max_duration_minutes": 90,
+    "preferred_activity_duration": {},
+    "energy_levels": {},
+    "social_preferences": {},
+    "rest_preferences": {},
+    "created_at": 1,
+    "updated_at": 1,
+}
+
+
+def test_create_preferences(monkeypatch):
+    client = create_test_client()
+
+    get_call_results = [None, SAVED_PREFS]
+    def mock_get(uid):
+        return get_call_results.pop(0)
+    monkeypatch.setattr("app.user_preferences_router.get_user_preferences", mock_get)
+    monkeypatch.setattr("app.user_preferences_router.save_user_preferences", lambda prefs: "success")
+
+    payload = {
+        "user_id": "test_user",
+        "time_zone": "UTC",
+        "working_hours": {"monday": {"start": "09:00", "end": "17:00"}},
+    }
+    resp = client.post("/preferences/test_user", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["user_id"] == "test_user"
+
+
+def test_get_preferences(monkeypatch):
+    client = create_test_client()
+    monkeypatch.setattr("app.user_preferences_router.get_user_preferences", lambda uid: SAVED_PREFS)
+    resp = client.get("/preferences/test_user")
+    assert resp.status_code == 200
+    assert resp.json()["user_id"] == "test_user"
+
+
+def test_update_preferences(monkeypatch):
+    client = create_test_client()
+    monkeypatch.setattr("app.user_preferences_router.get_user_preferences", lambda uid: SAVED_PREFS)
+    monkeypatch.setattr("app.user_preferences_router.update_user_preferences", lambda uid, updates: "success")
+    resp = client.put("/preferences/test_user", json={"time_zone": "UTC"})
+    assert resp.status_code == 200
+
+
+def test_delete_preferences(monkeypatch):
+    client = create_test_client()
+    monkeypatch.setattr("app.user_preferences_router.get_user_preferences", lambda uid: SAVED_PREFS)
+    monkeypatch.setattr("app.user_preferences_router.delete_user_preferences", lambda uid: True)
+    resp = client.delete("/preferences/test_user")
+    assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- add fixtures and helper for routing tests
- add tests covering auth, chat, events, conversations and preferences routers

## Testing
- `pytest -q`