### PR TITLE
Add missing unit tests

### DIFF
--- a/tests/test_calendar_client_module.py
+++ b/tests/test_calendar_client_module.py
@@ -1,0 +1,33 @@
+import pytest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from app.calendar_client import GoogleCalendarAPIClient
+from app.models import TimeSlot
+
+
+def test_calculate_free_slots_basic():
+    tz = ZoneInfo("UTC")
+    start = datetime(2024, 1, 1, 8, 0, tzinfo=tz)
+    end = datetime(2024, 1, 1, 18, 0, tzinfo=tz)
+    busy = [
+        TimeSlot(start_time=datetime(2024, 1, 1, 10, 0, tzinfo=tz), end_time=datetime(2024, 1, 1, 11, 0, tzinfo=tz)),
+        TimeSlot(start_time=datetime(2024, 1, 1, 13, 0, tzinfo=tz), end_time=datetime(2024, 1, 1, 14, 30, tzinfo=tz)),
+    ]
+    client = GoogleCalendarAPIClient(token_info={"access_token": "a", "refresh_token": "r", "app_user_id": "u"})
+    free = client.calculate_free_slots(busy, start, end)
+    assert [(s.start_time, s.end_time) for s in free] == [
+        (start, datetime(2024, 1, 1, 10, 0, tzinfo=tz)),
+        (datetime(2024, 1, 1, 11, 0, tzinfo=tz), datetime(2024, 1, 1, 13, 0, tzinfo=tz)),
+        (datetime(2024, 1, 1, 14, 30, tzinfo=tz), end),
+    ]
+
+
+def test_calculate_free_slots_validation():
+    tz = ZoneInfo("UTC")
+    start = datetime(2024, 1, 1, 8, 0, tzinfo=tz)
+    end = datetime(2024, 1, 1, 18, 0, tzinfo=tz)
+    client = GoogleCalendarAPIClient(token_info={"access_token": "a", "refresh_token": "r", "app_user_id": "u"})
+    with pytest.raises(ValueError):
+        client.calculate_free_slots([], start.replace(tzinfo=None), end)
+    with pytest.raises(ValueError):
+        client.calculate_free_slots([], start, start)

--- a/tests/test_gemini_interface_module.py
+++ b/tests/test_gemini_interface_module.py
@@ -1,0 +1,37 @@
+import json
+from app.gemini_interface import (
+    FunctionCall,
+    ToolResult,
+    ConversationTurn,
+    ConversationRole,
+    GeminiRequest,
+    GeminiResponse,
+    ResponseType,
+)
+
+
+def test_conversation_turn_helpers():
+    fc = FunctionCall(name="do", args={"a": 1})
+    tr = ToolResult(name="do", response={"status": "ok"})
+
+    user_turn = ConversationTurn.user_turn("hi")
+    fc_turn = ConversationTurn.model_turn_function_call(fc)
+    func_turn = ConversationTurn.function_turn(tr)
+    text_turn = ConversationTurn.model_turn_text("bye")
+
+    assert user_turn.role is ConversationRole.USER
+    assert user_turn.parts == ["USER: hi"]
+    assert fc_turn.role is ConversationRole.MODEL
+    assert "AI FUNCTION CALL" in fc_turn.parts[0]
+    assert func_turn.role is ConversationRole.FUNCTION
+    assert "FUNCTION RESULT" in func_turn.parts[0]
+    assert text_turn.parts == ["AI: bye"]
+
+
+def test_request_and_response_models():
+    turn = ConversationTurn.user_turn("hello")
+    req = GeminiRequest(history=[turn], tools=[{"name": "t"}])
+    resp = GeminiResponse(response_type=ResponseType.TEXT, text="out")
+
+    assert req.history[0].role is ConversationRole.USER
+    assert json.loads(resp.model_dump_json())["text"] == "out"

--- a/tests/test_orchestration_service_module.py
+++ b/tests/test_orchestration_service_module.py
@@ -1,0 +1,103 @@
+import pytest
+from app import orchestration_service as orch
+from app.models import ChatRequest, ResponseStatus
+from app.gemini_interface import GeminiResponse, ResponseType, FunctionCall
+
+
+class DummySessionManager(orch.AbstractSessionManager):
+    def __init__(self):
+        self.history = []
+
+    async def get_history(self, session_id: str):
+        return list(self.history)
+
+    async def append_turn(self, session_id: str, turn):
+        self.history.append(turn)
+
+    async def create_session(self, user_id: str, session_id: str):
+        self.history = []
+        return session_id
+
+
+class DummyGeminiClient(orch.AbstractGeminiClient):
+    def __init__(self, responses):
+        self.responses = responses
+
+    async def send_to_gemini(self, request):
+        return self.responses.pop(0)
+
+
+class DummyToolExecutor(orch.AbstractToolExecutor):
+    def __init__(self, executed):
+        self.executed = executed
+
+    def execute_tool(self, call, context):
+        self.executed.append(call.name)
+        return orch.ExecutorToolResult(name=call.name, status=orch.ToolResultStatus.SUCCESS, result={})
+
+
+class DummyCalendarClient(orch.AbstractCalendarClient):
+    def authenticate(self):
+        pass
+
+    def get_busy_slots(self, *a, **k):
+        return []
+
+    def calculate_free_slots(self, *a, **k):
+        return []
+
+    def get_available_time_slots(self, *a, **k):
+        return []
+
+    def add_event(self, *a, **k):
+        return {}
+
+
+import asyncio
+
+
+def test_handle_chat_request_text(monkeypatch):
+    session = DummySessionManager()
+    gemini = DummyGeminiClient([GeminiResponse(response_type=ResponseType.TEXT, text="hi")])
+    executed = []
+    tool_exec = DummyToolExecutor(executed)
+    cal = DummyCalendarClient()
+
+    monkeypatch.setattr(orch, "TOOL_DEFINITIONS", [])
+    async def dummy_prefs(uid):
+        return orch.DummyPrefs(user_id=uid)
+    monkeypatch.setattr(orch, "get_user_preferences", dummy_prefs)
+
+    req = ChatRequest(user_id="u1", session_id="s1", prompt_text="hello")
+    resp = asyncio.run(
+        orch.handle_chat_request(req, session, gemini, tool_exec, cal)
+    )
+    assert resp.status == ResponseStatus.COMPLETED
+    assert resp.response_text == "hi"
+    assert executed == []
+
+
+def test_handle_chat_request_function_call(monkeypatch):
+    session = DummySessionManager()
+    fc = FunctionCall(name="do", args={})
+    responses = [
+        GeminiResponse(response_type=ResponseType.FUNCTION_CALL, function_call=fc),
+        GeminiResponse(response_type=ResponseType.TEXT, text="done"),
+    ]
+    gemini = DummyGeminiClient(responses)
+    executed = []
+    tool_exec = DummyToolExecutor(executed)
+    cal = DummyCalendarClient()
+
+    monkeypatch.setattr(orch, "TOOL_DEFINITIONS", [])
+    async def dummy_prefs(uid):
+        return orch.DummyPrefs(user_id=uid)
+    monkeypatch.setattr(orch, "get_user_preferences", dummy_prefs)
+
+    req = ChatRequest(user_id="u1", session_id="s1", prompt_text="hi")
+    resp = asyncio.run(
+        orch.handle_chat_request(req, session, gemini, tool_exec, cal)
+    )
+    assert executed == ["do"]
+    assert resp.status == ResponseStatus.COMPLETED
+    assert resp.response_text == "done"


### PR DESCRIPTION
## Summary
- add tests for GoogleCalendarAPIClient.calculate_free_slots
- cover ConversationTurn helpers and request/response dataclasses
- add orchestration service unit tests exercising basic flows

## Testing
- `pytest -q`