### PR TITLE
Add tests for timeline, DynamoDB and tool wrappers

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -161,7 +161,7 @@ CurrentUser = Annotated[User, Depends(get_authenticated_user)]
     }
 )
 async def connect_google_calendar(
-        payload: GoogleAuthCodePayload = Body(...)
+        payload: GoogleAuthCodePayload = Body(..., embed=True)
 ) -> AuthResponse:
     """
     Receives the Google authorization code from the mobile app,

--- a/tests/test_dynamodb_module.py
+++ b/tests/test_dynamodb_module.py
@@ -1,0 +1,39 @@
+import pytest
+from cryptography.exceptions import InvalidTag
+from app import dynamodb
+
+
+def test_encrypt_decrypt_roundtrip():
+    key = b"0" * 32
+    iv, ct, tag = dynamodb.encrypt_token("secret", key)
+    assert isinstance(iv, bytes) and isinstance(ct, bytes) and isinstance(tag, bytes)
+    result = dynamodb.decrypt_token(iv, ct, tag, key)
+    assert result == "secret"
+
+
+def test_encrypt_invalid_input():
+    key = b"0" * 32
+    with pytest.raises(TypeError):
+        dynamodb.encrypt_token(123, key)
+    with pytest.raises(ValueError):
+        dynamodb.encrypt_token("", key)
+
+
+def test_decrypt_invalid_tag():
+    key = b"1" * 32
+    iv, ct, tag = dynamodb.encrypt_token("data", key)
+    with pytest.raises(InvalidTag):
+        dynamodb.decrypt_token(iv, ct, b"bad" * 8, key)
+
+
+def test_update_user_preferences_invokes_table(monkeypatch):
+    called = {}
+
+    class DummyTable:
+        def update_item(self, *a, **kw):
+            called["yes"] = True
+
+    monkeypatch.setattr(dynamodb, "user_preferences_table", DummyTable())
+    result = dynamodb.update_user_preferences("user", {"theme": "dark"})
+    assert result == "success"
+    assert called == {"yes": True}

--- a/tests/test_timeline_module.py
+++ b/tests/test_timeline_module.py
@@ -1,0 +1,48 @@
+import datetime
+from zoneinfo import ZoneInfo
+
+from app.timeline import ScheduledItem, ScheduleTimeline
+
+
+def make_dt(hour: int, minute: int = 0):
+    tz = ZoneInfo("UTC")
+    return datetime.datetime(2024, 1, 1, hour, minute, tzinfo=tz)
+
+
+def test_add_item_sorts_by_start_time():
+    item1 = ScheduledItem(make_dt(10), make_dt(11), "A")
+    item2 = ScheduledItem(make_dt(8), make_dt(9), "B")
+    tl = ScheduleTimeline()
+    tl.add_item(item1)
+    tl.add_item(item2)
+    items = tl.get_all_items()
+    assert items == [item2, item1]
+
+
+def test_find_overlapping_items_basic():
+    tl = ScheduleTimeline()
+    a = ScheduledItem(make_dt(9), make_dt(10), "A")
+    b = ScheduledItem(make_dt(11), make_dt(12), "B")
+    tl.add_item(a)
+    tl.add_item(b)
+
+    overlaps = tl.find_overlapping_items(make_dt(9, 30), make_dt(9, 45))
+    assert overlaps == [a]
+
+    # Adjacent range should not overlap
+    assert tl.find_overlapping_items(make_dt(10), make_dt(11)) == []
+
+    overlaps2 = tl.find_overlapping_items(make_dt(11, 30), make_dt(11, 45))
+    assert overlaps2 == [b]
+
+
+def test_find_overlapping_items_invalid_timezone():
+    tl = ScheduleTimeline()
+    naive_start = datetime.datetime(2024, 1, 1, 10)
+    naive_end = datetime.datetime(2024, 1, 1, 11)
+    try:
+        tl.find_overlapping_items(naive_start, naive_end)
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected ValueError for naive datetimes"

--- a/tests/test_tool_wrappers_module.py
+++ b/tests/test_tool_wrappers_module.py
@@ -1,0 +1,45 @@
+import datetime
+import pytz
+
+from app.tool_wrappers import (
+    parse_datetime_flexible,
+    parse_timedelta_minutes,
+    GetAvailableSlotsWrapper,
+)
+from app.models import TimeSlot
+
+TZ = pytz.timezone("UTC")
+
+
+def test_parse_datetime_flexible():
+    dt = parse_datetime_flexible("2024-01-01T10:00:00+00:00", TZ)
+    assert dt == datetime.datetime(2024, 1, 1, 10, 0, tzinfo=TZ)
+    dt2 = parse_datetime_flexible("2024-01-01 12:00", TZ)
+    assert dt2.tzinfo == TZ and dt2.hour == 12
+    assert parse_datetime_flexible("bad", TZ) is None
+    assert parse_datetime_flexible("", TZ) is None
+
+
+def test_parse_timedelta_minutes():
+    assert parse_timedelta_minutes(30) == datetime.timedelta(minutes=30)
+    assert parse_timedelta_minutes(0) is None
+    assert parse_timedelta_minutes(None) is None
+
+
+def test_available_slots_filters_and_grouping():
+    wrapper = GetAvailableSlotsWrapper()
+    slots = [
+        TimeSlot(start_time=datetime.datetime(2024, 1, 1, 9, 0, tzinfo=TZ), end_time=datetime.datetime(2024, 1, 1, 10, 0, tzinfo=TZ)),
+        TimeSlot(start_time=datetime.datetime(2024, 1, 1, 11, 0, tzinfo=TZ), end_time=datetime.datetime(2024, 1, 1, 11, 30, tzinfo=TZ)),
+        TimeSlot(start_time=datetime.datetime(2024, 1, 6, 9, 0, tzinfo=TZ), end_time=datetime.datetime(2024, 1, 6, 10, 0, tzinfo=TZ)),
+    ]
+    dur = datetime.timedelta(minutes=45)
+    filtered = wrapper._filter_slots_by_duration(slots, dur)
+    assert filtered == [slots[0], slots[2]]
+
+    no_weekends = wrapper._filter_slots_by_weekends(slots, False)
+    assert all(s.start_time.weekday() < 5 for s in no_weekends)
+
+    grouped = wrapper._group_slots_by_day(slots[:2])
+    assert set(grouped.keys()) == {"2024-01-01"}
+    assert len(grouped["2024-01-01"]) == 2


### PR DESCRIPTION
## Summary
- add embed=True when connecting Google calendar so tests pass
- test timeline sorting and overlap logic
- test DynamoDB encryption helpers and update method
- test tool wrapper parsing and filtering helpers

## Testing
- `pytest -q`