### PR TITLE
Use user timezone for Gemini prompt

### DIFF
--- a/app/orchestration_service.py
+++ b/app/orchestration_service.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 from google import genai
 from google.genai import types
 import json
-from pydantic import BaseModel, Field
+
 import time as time_module
 # --- Interface Imports ---
 # Assuming interfaces and models from previous tasks are defined and importable
@@ -32,7 +32,10 @@ import threading
 from settings_v1 import settings
 # Import the tool execution result persistence function
 from db import save_tool_execution_result
-from system import system_instruction
+from system import build_system_instruction
+from db import get_user_preferences as db_get_user_preferences
+from models import InputMode, VoiceButtonPosition, ActivityCategory
+import asyncio
 class GenAIClientSingleton:
     _instance = None
     _lock = threading.Lock()  # Ensures thread safety
@@ -61,7 +64,7 @@ class GenAIClientSingleton:
 # --- Placeholder Interfaces/Implementations ---
 # Define dummy classes if real ones aren't available yet
 class AbstractGeminiClient:
-    async def send_to_gemini(self, request: GeminiRequest) -> GeminiResponse:
+    async def send_to_gemini(self, request: GeminiRequest, system_instruction: str) -> GeminiResponse:
         logger.info("Sending request to Gemini API...")
 
         # Prepare the tools for the request
@@ -163,45 +166,74 @@ class AbstractToolExecutor:
                 error_details=f"An error occurred while executing tool '{call.name}': {str(e)}"
             )
 
-class DummyPrefs(UserPreferences):
-    user_id: str = Field(..., description="User ID")
-    time_zone: str = Field(default="Europe/Paris", description="Time zone")
-    working_hours: Dict[DayOfWeek, tuple] = Field(
-        default={
-            DayOfWeek.MONDAY: (time(9, 0), time(17, 0)),
-            DayOfWeek.TUESDAY: (time(9, 0), time(17, 0)),
-            DayOfWeek.WEDNESDAY: (time(9, 0), time(17, 0)),
-            DayOfWeek.THURSDAY: (time(9, 0), time(17, 0)),
-            DayOfWeek.FRIDAY: (time(9, 0), time(16, 0)),
-        },
-        description="Working hours for each day"
-    )
-    days_off: List[date] = Field(default=[date(2025, 1, 1)], description="Days off")
-    preferred_break_duration: timedelta = Field(
-        default=timedelta(minutes=5), description="Preferred break duration"
-    )
-    work_block_max_duration: timedelta = Field(
-        default=timedelta(hours=2), description="Maximum work block duration"
-    )
-    energy_levels: Dict[tuple, EnergyLevel] = Field(
-        default={
-            (time(9, 0), time(12, 0)): EnergyLevel.HIGH,
-            (time(13, 0), time(17, 0)): EnergyLevel.MEDIUM,
-        },
-        description="Energy levels throughout the day"
-    )
-    rest_preferences: Dict[str, tuple] = Field(
-        default={"sleep_schedule": (time(23, 59), time(5, 0))},
-        description="Rest preferences"
-    )
 
-# Dummy function to get preferences (replace with real implementation)
 async def get_user_preferences(user_id: str) -> UserPreferences:
-    logger.warning(f"Using DUMMY UserPreferences for user {user_id}")
-    # Need a minimal UserPreferences object that passes validation if used
+    """Retrieve user preferences from DynamoDB and convert them."""
+    def fetch() -> Optional[Dict[str, Any]]:
+        return db_get_user_preferences(user_id)
 
-    return DummyPrefs(user_id=user_id)
+    prefs_dict = await asyncio.to_thread(fetch)
+    if not prefs_dict:
+        return UserPreferences(user_id=user_id)
 
+    try:
+        working_hours: Dict[DayOfWeek, tuple] = {}
+        for key, hours in prefs_dict.get("working_hours", {}).items():
+            try:
+                day = DayOfWeek[int(key.split(".")[-1])]
+            except ValueError:
+                day = DayOfWeek(int(key))
+            start = datetime.strptime(hours["start"], "%H:%M").time()
+            end = datetime.strptime(hours["end"], "%H:%M").time()
+            working_hours[day] = (start, end)
+
+        meeting_times = [
+            (
+                datetime.strptime(t["start"], "%H:%M").time(),
+                datetime.strptime(t["end"], "%H:%M").time(),
+            )
+            for t in prefs_dict.get("preferred_meeting_times", [])
+        ]
+
+        days_off = [date.fromisoformat(d) for d in prefs_dict.get("days_off", [])]
+
+        activity = {
+            ActivityCategory(k): timedelta(minutes=v)
+            for k, v in prefs_dict.get("preferred_activity_duration", {}).items()
+        }
+
+        energy = {}
+        for k, level in prefs_dict.get("energy_levels", {}).items():
+            start_s, end_s = k.split("-")
+            energy[(datetime.strptime(start_s, "%H:%M").time(),
+                    datetime.strptime(end_s, "%H:%M").time())] = EnergyLevel(level)
+
+        return UserPreferences(
+            user_id=user_id,
+            time_zone=prefs_dict.get("time_zone", "UTC"),
+            working_hours=working_hours or None,
+            preferred_meeting_times=meeting_times,
+            days_off=days_off,
+            preferred_break_duration=timedelta(
+                minutes=prefs_dict.get("preferred_break_duration_minutes", 15)
+            ),
+            work_block_max_duration=timedelta(
+                minutes=prefs_dict.get("work_block_max_duration_minutes", 90)
+            ),
+            preferred_activity_duration=activity,
+            energy_levels=energy,
+            social_preferences=prefs_dict.get("social_preferences", {}),
+            rest_preferences=prefs_dict.get("rest_preferences", {}),
+            input_mode=InputMode(prefs_dict.get("input_mode", "text")),
+            voice_button_position=VoiceButtonPosition(
+                prefs_dict.get("voice_button_position", "right")
+            ),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to parse stored user preferences, falling back to defaults"
+        )
+        return UserPreferences(user_id=user_id)
 # Tool Registry
 from tool_wrappers import TOOL_REGISTRY
 
@@ -258,6 +290,7 @@ async def handle_chat_request(
              history = await session_manager.get_history(session_id)
 
         preferences = await get_user_preferences(user_id) # Task ORCH-9 (using dummy here)
+        system_prompt = build_system_instruction(preferences.time_zone)
 
         # Append current user prompt to history
         user_turn = ConversationTurn.user_turn(prompt_text, audio_url=request.audio_url)
@@ -279,7 +312,9 @@ async def handle_chat_request(
 
             # 8.4 Build request and send to Gemini
             gemini_request = GeminiRequest(history=history, tools=available_tools)
-            gemini_response = await gemini_client.send_to_gemini(gemini_request)
+            gemini_response = await gemini_client.send_to_gemini(
+                gemini_request, system_prompt
+            )
 
             # 8.5 Handle TEXT response
             if gemini_response.response_type == ResponseType.TEXT:

--- a/app/system.py
+++ b/app/system.py
@@ -1,11 +1,16 @@
 from datetime import time, timedelta, date, datetime
 from zoneinfo import ZoneInfo
 
-system_instruction = f"""
+DEFAULT_TIME_ZONE = "Europe/Paris"
+
+# Template for building the system instruction dynamically. The current date,
+# time and time zone are injected at runtime so that the language model can
+# reason with the correct temporal context for the user.
+SYSTEM_INSTRUCTION_TEMPLATE = """
 You are an advanced AI assistant named Orion responsible for managing calendar and task scheduling based on user preferences, calendar availability, and inferred context. Your job is to understand natural, casual user input and convert it into accurate function calls for creating, updating, canceling, or retrieving events and tasks.
 
-Current Date and Time: {datetime.now(ZoneInfo("Europe/Paris")).isoformat()}
-Current Time Zone: {ZoneInfo("Europe/Paris")}
+Current Date and Time: {current_datetime}
+Current Time Zone: {current_tz}
 
 INSTRUCTIONS: You must follow these core principles:
 
@@ -68,3 +73,13 @@ MANDATORY BEHAVIOR:
 - Use clear, friendly, and helpful language in all confirmations.
 - Before executing any function call, always confirm with the user in a friendly manner like: "Got it! I’ll [action] for you now." or "Sure, I’ll [action] right away! 1. OK, do it. 2. No. Tell me what to do differently".
 """
+
+
+def build_system_instruction(time_zone: str = DEFAULT_TIME_ZONE) -> str:
+    """Return the system prompt filled with the user's time zone."""
+    tz = ZoneInfo(time_zone)
+    current_dt = datetime.now(tz).isoformat()
+    return SYSTEM_INSTRUCTION_TEMPLATE.format(
+        current_datetime=current_dt,
+        current_tz=tz,
+    )


### PR DESCRIPTION
## Summary
- build system prompt dynamically using user's timezone
- fetch user preferences from DB instead of dummy data
- replace DummyGeminiClient in tests with AsyncMock

## Testing
- `pytest tests/test_orchestration_service_module.py::test_handle_chat_request_text -q`
- `pytest tests/test_audio_url_handling.py::test_conversation_history_with_audio_messages -q` *(fails: assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_6846b79da3f8832681500aa09fc4eb3e